### PR TITLE
various readme edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Install LaOS itself:
 
     $ pip install -e .
 
+Install MySQL if you haven't already, and create a new database for functions.
+
+    $ mysql -uroot -p -e "CREATE DATABASE functions"
+
 
 Migrations
 ----------
@@ -76,10 +80,10 @@ Migrations
 Once all dependencies are installed it is necessary to run database migrations.
 Before that please edit [alembic.ini](alembic.ini) line #32
 
-    sqlalchemy.url = mysql+pymysql://root:root@192.168.0.112/functions
+    sqlalchemy.url = mysql+pymysql://root:root@localhost/functions
 
-In this section please specify connection URI to your own database.
-Once it is done just hit alembic to apply migrations:
+In this section please specify connection URI to your own MySQL database.
+Once the file is saved, just use alembic to apply the migrations:
 
     $ alembic upgrade head
 


### PR DESCRIPTION
The quick start is not explicit about exactly what actions need to be taken. For a few users this will not be a problem, but I feel for the majority of users a more detailed quick start guide would be helpful. 

For one, I think we can recommend Ubuntu 16.04 as a starting point, and that will be what the guide covers. We can provide detailed examples of how to get up and running on this supported OS.

This PR covers some initial missing details about getting MySQL prepared, and some minor word changes. 

If we agree that a detailed Ubuntu setup guide is beneficial, I can add the necessary commands, so users should be able to essentially copy and paste from the guide.